### PR TITLE
feat: improve error wrapping, stack trace management, and formatting

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -1,0 +1,280 @@
+package eris_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/rotisserie/eris"
+)
+
+// Demonstrates JSON formatting of wrapped errors that originate from
+// external (non-eris) error types.
+func ExampleUnpackedError_ToJSON_external() {
+	// example func that returns an IO error
+	readFile := func(fname string) error {
+		return io.ErrUnexpectedEOF
+	}
+
+	// unpack and print the error
+	err := readFile("example.json")
+	uerr := eris.Unpack(err)
+	format := eris.NewDefaultFormat(false) // false: omit stack trace
+	u, _ := json.Marshal(uerr.ToJSON(format))
+	fmt.Println(string(u))
+	// Output:
+	// {"external":"unexpected EOF"}
+}
+
+// Demonstrates JSON formatting of wrapped errors that originate from
+// global root errors (created via eris.NewGlobal).
+func ExampleUnpackedError_ToJSON_global() {
+	// declare a "global" error type
+	ErrUnexpectedEOF := eris.NewGlobal("unexpected EOF")
+
+	// example func that wraps a global error value
+	readFile := func(fname string) error {
+		return eris.Wrapf(ErrUnexpectedEOF, "error reading file '%v'", fname) // line 6
+	}
+
+	// example func that catches and returns an error without modification
+	parseFile := func(fname string) error {
+		// read the file
+		err := readFile(fname) // line 12
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// unpack and print the error via uerr.ToJSON(...)
+	err := parseFile("example.json") // line 20
+	uerr := eris.Unpack(err)
+	format := eris.NewDefaultFormat(true) // true: include stack trace
+	u, _ := json.MarshalIndent(uerr.ToJSON(format), "", "\t")
+	fmt.Printf("%v\n", string(u))
+
+	// example output:
+	// {
+	// 	"root": {
+	// 		"message": "unexpected EOF",
+	// 		"stack": [
+	// 			"main.readFile: .../example/main.go: 6",
+	// 			"main.parseFile: .../example/main.go: 12",
+	// 			"main.main: .../example/main.go: 20",
+	// 		]
+	// 	},
+	// 	"wrap": [
+	// 		{
+	// 			"message": "error reading file 'example.json'",
+	// 			"stack": "main.readFile: .../example/main.go: 6"
+	// 		}
+	// 	]
+	// }
+}
+
+// Hack to run examples that don't have a predictable output (i.e. all
+// examples that involve printing stack traces).
+func TestExampleUnpackedError_ToJSON_global(t *testing.T) {
+	if !testing.Verbose() {
+		return
+	}
+	ExampleUnpackedError_ToJSON_global()
+}
+
+// Demonstrates JSON formatting of wrapped errors that originate from
+// local root errors (created at the source of the error via eris.New).
+func ExampleUnpackedError_ToJSON_local() {
+	// example func that returns an eris error
+	readFile := func(fname string) error {
+		return eris.New("unexpected EOF") // line 3
+	}
+
+	// example func that catches an error and wraps it with additional context
+	parseFile := func(fname string) error {
+		// read the file
+		err := readFile(fname) // line 9
+		if err != nil {
+			return eris.Wrapf(err, "error reading file '%v'", fname) // line 11
+		}
+		return nil
+	}
+
+	// example func that just catches and returns an error
+	processFile := func(fname string) error {
+		// parse the file
+		err := parseFile(fname) // line 19
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// another example func that catches and wraps an error
+	printFile := func(fname string) error {
+		// process the file
+		err := processFile(fname) // line 29
+		if err != nil {
+			return eris.Wrapf(err, "error printing file '%v'", fname) // line 31
+		}
+		return nil
+	}
+
+	// unpack and print the raw error
+	err := printFile("example.json") // line 37
+	uerr := eris.Unpack(err)
+	format := eris.NewDefaultFormat(true) // true: include stack trace
+	u, _ := json.MarshalIndent(uerr.ToJSON(format), "", "\t")
+	fmt.Printf("%v\n", string(u))
+
+	// example output:
+	// 	{
+	// 	"root": {
+	// 		"message": "unexpected EOF",
+	// 		"stack": [
+	// 			"main.readFile: .../example/main.go: 3",
+	// 			"main.parseFile: .../example/main.go: 9",
+	// 			"main.parseFile: .../example/main.go: 11",
+	// 			"main.processFile: .../example/main.go: 19",
+	// 			"main.printFile: .../example/main.go: 29",
+	// 			"main.printFile: .../example/main.go: 31",
+	// 			"main.main: .../example/main.go: 37",
+	// 		]
+	// 	},
+	// 	"wrap": [
+	// 		{
+	// 			"message": "error reading file 'example.json'",
+	// 			"stack": "main.parseFile: .../example/main.go: 11"
+	// 		},
+	// 		{
+	// 			"message": "error printing file 'example.json'",
+	// 			"stack": "main.printFile: .../example/main.go: 31"
+	// 		}
+	// 	]
+	// }
+}
+
+func TestExampleUnpackedError_ToJSON_local(t *testing.T) {
+	if !testing.Verbose() {
+		return
+	}
+	ExampleUnpackedError_ToJSON_local()
+}
+
+// Demonstrates string formatting of wrapped errors that originate from
+// external (non-eris) error types.
+func ExampleUnpackedError_ToString_external() {
+	// example func that returns an IO error
+	readFile := func(fname string) error {
+		return io.ErrUnexpectedEOF
+	}
+
+	// unpack and print the error
+	err := readFile("example.json")
+	uerr := eris.Unpack(err)
+	format := eris.NewDefaultFormat(false) // false: omit stack trace
+	fmt.Println(uerr.ToString(format))
+	// Output:
+	// unexpected EOF
+}
+
+// Demonstrates string formatting of wrapped errors that originate from
+// global root errors (created via eris.NewGlobal).
+func ExampleUnpackedError_ToString_global() {
+	// declare a "global" error type
+	ErrUnexpectedEOF := eris.NewGlobal("unexpected EOF")
+
+	// example func that wraps a global error value
+	readFile := func(fname string) error {
+		return eris.Wrapf(ErrUnexpectedEOF, "error reading file '%v'", fname) // line 6
+	}
+
+	// example func that catches and returns an error without modification
+	parseFile := func(fname string) error {
+		// read the file
+		err := readFile(fname) // line 12
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// call parseFile and catch the error
+	err := parseFile("example.json") // line 20
+
+	// print the error via fmt.Printf
+	fmt.Printf("%v\n", err) // %v: omit stack trace
+
+	// example output:
+	// unexpected EOF: error reading file 'example.json'
+
+	// unpack and print the error via uerr.ToString(...)
+	uerr := eris.Unpack(err)
+	format := eris.NewDefaultFormat(true) // true: include stack trace
+	fmt.Printf("%v\n", uerr.ToString(format))
+
+	// example output:
+	// unexpected EOF
+	// 	main.readFile: .../example/main.go: 6
+	// 	main.parseFile: .../example/main.go: 12
+	// 	main.main: .../example/main.go: 20
+	// error reading file 'example.json'
+	// 	main.readFile: .../example/main.go: 6
+}
+
+func TestExampleUnpackedError_ToString_global(t *testing.T) {
+	if !testing.Verbose() {
+		return
+	}
+	ExampleUnpackedError_ToString_global()
+}
+
+// Demonstrates string formatting of wrapped errors that originate from
+// local root errors (created at the source of the error via eris.New).
+func ExampleUnpackedError_ToString_local() {
+	// example func that returns an eris error
+	readFile := func(fname string) error {
+		return eris.New("unexpected EOF") // line 3
+	}
+
+	// example func that catches an error and wraps it with additional context
+	parseFile := func(fname string) error {
+		// read the file
+		err := readFile(fname) // line 9
+		if err != nil {
+			return eris.Wrapf(err, "error reading file '%v'", fname) // line 11
+		}
+		return nil
+	}
+
+	// call parseFile and catch the error
+	err := parseFile("example.json") // line 17
+
+	// print the error via fmt.Printf
+	fmt.Printf("%v\n", err) // %v: omit stack trace
+
+	// example output:
+	// unexpected EOF: error reading file 'example.json'
+
+	// unpack and print the error via uerr.ToString(...)
+	uerr := eris.Unpack(err)
+	format := eris.NewDefaultFormat(true) // true: include stack trace
+	fmt.Println(uerr.ToString(format))
+
+	// example output:
+	// unexpected EOF
+	// 	main.readFile: .../example/main.go: 3
+	// 	main.parseFile: .../example/main.go: 9
+	// 	main.parseFile: .../example/main.go: 11
+	// 	main.main: .../example/main.go: 17
+	// error reading file 'example.json'
+	// 	main.parseFile: .../example/main.go: 11
+}
+
+func TestExampleUnpackedError_ToString_local(t *testing.T) {
+	if !testing.Verbose() {
+		return
+	}
+	ExampleUnpackedError_ToString_local()
+}

--- a/format.go
+++ b/format.go
@@ -34,130 +34,127 @@ func NewDefaultFormat(withTrace bool) Format {
 // from any error type. The ErrChain and ErrRoot fields correspond to `wrapError` and `rootError` types,
 // respectively. If any other error type is unpacked, it will appear in the ExternalErr field.
 type UnpackedError struct {
-	ErrChain    *[]ErrLink
-	ErrRoot     *ErrRoot
+	ErrRoot     ErrRoot
+	ErrChain    []ErrLink
 	ExternalErr string
 }
 
 // Unpack returns UnpackedError type for a given golang error type.
 func Unpack(err error) UnpackedError {
-	e := UnpackedError{}
+	upErr := UnpackedError{}
 	switch err := err.(type) {
 	case nil:
-		return UnpackedError{}
+		return upErr
 	case *rootError:
-		e = unpackRootErr(err)
+		upErr.unpackRootErr(err)
 	case *wrapError:
-		chain := []ErrLink{}
-		e = unpackWrapErr(&chain, err)
+		upErr.unpackWrapErr(err)
 	default:
-		e.ExternalErr = err.Error()
+		upErr.ExternalErr = err.Error()
 	}
-	return e
+	return upErr
 }
 
 // ToString returns a default formatted string for a given eris error.
 func (upErr *UnpackedError) ToString(format Format) string {
 	var str string
-	if upErr.ErrChain != nil {
-		for _, eLink := range *upErr.ErrChain {
-			str += eLink.formatStr(format)
+	if upErr.ErrRoot.Msg != "" || len(upErr.ErrRoot.Stack) > 0 {
+		str += upErr.ErrRoot.formatStr(format)
+		if format.WithTrace && len(upErr.ErrChain) > 0 {
+			str += format.Sep
 		}
 	}
-	str += upErr.ErrRoot.formatStr(format)
+
+	for _, eLink := range upErr.ErrChain {
+		if !format.WithTrace {
+			str += format.Sep
+		}
+		str += eLink.formatStr(format)
+	}
+
 	if upErr.ExternalErr != "" {
 		str += fmt.Sprint(upErr.ExternalErr)
 	}
+
 	return str
 }
 
 // ToJSON returns a JSON formatted map for a given eris error.
 func (upErr *UnpackedError) ToJSON(format Format) map[string]interface{} {
-	if upErr == nil {
-		return nil
-	}
 	jsonMap := make(map[string]interface{})
-	if fmtRootErr := upErr.ErrRoot.formatJSON(format); fmtRootErr != nil {
-		jsonMap["error root"] = fmtRootErr
+	if upErr.ErrRoot.Msg != "" || len(upErr.ErrRoot.Stack) > 0 {
+		jsonMap["root"] = upErr.ErrRoot.formatJSON(format)
 	}
-	if upErr.ErrChain != nil {
+
+	if len(upErr.ErrChain) > 0 {
 		var wrapArr []map[string]interface{}
-		for _, eLink := range *upErr.ErrChain {
+		for _, eLink := range upErr.ErrChain {
 			wrapMap := eLink.formatJSON(format)
 			wrapArr = append(wrapArr, wrapMap)
 		}
-		jsonMap["error chain"] = wrapArr
+		jsonMap["wrap"] = wrapArr
 	}
+
 	if upErr.ExternalErr != "" {
-		jsonMap["external error"] = fmt.Sprint(upErr.ExternalErr)
+		jsonMap["external"] = fmt.Sprint(upErr.ExternalErr)
 	}
+
 	return jsonMap
 }
 
-func unpackRootErr(err *rootError) UnpackedError {
-	return UnpackedError{
-		ErrRoot: &ErrRoot{
-			Msg:   err.msg,
-			Stack: err.stack.get(),
-		},
-	}
+func (upErr *UnpackedError) unpackRootErr(err *rootError) {
+	upErr.ErrRoot.Msg = err.msg
+	upErr.ErrRoot.Stack = err.stack.get()
 }
 
-func unpackWrapErr(chain *[]ErrLink, err *wrapError) UnpackedError {
-	link := ErrLink{}
-	link.Frame = *err.frame.get()
-	link.Msg = err.msg
-	*chain = append(*chain, link)
-
-	e := UnpackedError{}
-	e.ErrChain = chain
+func (upErr *UnpackedError) unpackWrapErr(err *wrapError) {
+	// prepend links in stack trace order
+	link := ErrLink{Msg: err.msg}
+	wFrames := err.stack.get()
+	if len(wFrames) > 0 {
+		link.Frame = wFrames[0]
+	}
+	upErr.ErrChain = append([]ErrLink{link}, upErr.ErrChain...)
 
 	nextErr := err.Unwrap()
 	switch nextErr := nextErr.(type) {
-	case nil:
-		return e
 	case *rootError:
-		uErr := unpackRootErr(nextErr)
-		e.ErrRoot = uErr.ErrRoot
+		upErr.unpackRootErr(nextErr)
 	case *wrapError:
-		e = unpackWrapErr(chain, nextErr)
-	default:
-		e.ExternalErr = err.Error()
+		upErr.unpackWrapErr(nextErr)
 	}
-	return e
+
+	// insert the wrap frame into the root stack
+	upErr.ErrRoot.Stack.insertFrame(wFrames)
 }
 
 // ErrRoot represents an error stack and the accompanying message.
 type ErrRoot struct {
 	Msg   string
-	Stack []StackFrame
+	Stack Stack
 }
 
 func (err *ErrRoot) formatStr(format Format) string {
-	if err == nil {
-		return ""
-	}
 	str := err.Msg
 	str += format.Msg
 	if format.WithTrace {
-		stackArr := formatStackFrames(err.Stack, format.TSep)
-		for _, frame := range stackArr {
+		stackArr := err.Stack.format(format.TSep)
+		for i, frame := range stackArr {
 			str += format.TBeg
 			str += frame
-			str += format.Sep
+			if i < len(stackArr)-1 {
+				str += format.Sep
+			}
 		}
 	}
 	return str
 }
 
 func (err *ErrRoot) formatJSON(format Format) map[string]interface{} {
-	if err == nil {
-		return nil
-	}
 	rootMap := make(map[string]interface{})
 	rootMap["message"] = fmt.Sprint(err.Msg)
 	if format.WithTrace {
-		rootMap["stack"] = formatStackFrames(err.Stack, format.TSep)
+		rootMap["stack"] = err.Stack.format(format.TSep)
 	}
 	return rootMap
 }
@@ -169,14 +166,12 @@ type ErrLink struct {
 }
 
 func (eLink *ErrLink) formatStr(format Format) string {
-	var str string
-	str += eLink.Msg
+	str := eLink.Msg
 	str += format.Msg
 	if format.WithTrace {
 		str += format.TBeg
-		str += eLink.Frame.formatFrame(format.TSep)
+		str += eLink.Frame.format(format.TSep)
 	}
-	str += format.Sep
 	return str
 }
 
@@ -184,15 +179,7 @@ func (eLink *ErrLink) formatJSON(format Format) map[string]interface{} {
 	wrapMap := make(map[string]interface{})
 	wrapMap["message"] = fmt.Sprint(eLink.Msg)
 	if format.WithTrace {
-		wrapMap["stack"] = eLink.Frame.formatFrame(format.TSep)
+		wrapMap["stack"] = eLink.Frame.format(format.TSep)
 	}
 	return wrapMap
-}
-
-func formatStackFrames(s []StackFrame, sep string) []string {
-	var str []string
-	for _, f := range s {
-		str = append(str, f.formatFrame(sep))
-	}
-	return str
 }

--- a/stack.go
+++ b/stack.go
@@ -6,6 +6,39 @@ import (
 	"strings"
 )
 
+// Stack is an array of stack frames stored in a human readable format.
+type Stack []StackFrame
+
+// insertFrames inserts a wrap error frame into the correct place of the root error stack trace.
+func (s *Stack) insertFrame(wFrames []StackFrame) {
+	if s == nil || len(wFrames) == 0 {
+		return
+	} else if len(wFrames) == 1 {
+		// append the frame to the end if there's only one
+		*s = append(*s, wFrames[0])
+	}
+
+	for at, f := range *s {
+		if f == wFrames[0] {
+			// return if the stack already contains the frame
+			return
+		} else if f == wFrames[1] {
+			// insert the first frame into the stack if the second frame is found
+			*s = insert(*s, wFrames[0], at)
+			break
+		}
+	}
+}
+
+// format returns an array of formatted stack frames.
+func (s Stack) format(sep string) []string {
+	var str []string
+	for _, f := range s {
+		str = append(str, f.format(sep))
+	}
+	return str
+}
+
 // StackFrame stores a frame's runtime information in a human readable format.
 type StackFrame struct {
 	Name string
@@ -13,16 +46,9 @@ type StackFrame struct {
 	Line int
 }
 
-func (f *StackFrame) formatFrame(sep string) string {
+// format returns a formatted stack frame.
+func (f *StackFrame) format(sep string) string {
 	return fmt.Sprintf("%v%v%v%v%v", f.Name, sep, f.File, sep, f.Line)
-}
-
-// caller returns a single stack frame. the argument skip is the number of stack frames
-// to ascend, with 0 identifying the caller of Caller.
-func caller(skip int) *frame {
-	pc, _, _, _ := runtime.Caller(skip)
-	var f frame = frame(pc)
-	return &f
 }
 
 // callers returns a stack trace. the argument skip is the number of stack frames to skip
@@ -32,21 +58,19 @@ func callers(skip int) *stack {
 	const depth = 64
 	var pcs [depth]uintptr
 	n := runtime.Callers(skip, pcs[:])
-	var st stack = pcs[0:n]
+	var st stack = pcs[0 : n-2]
 	return &st
 }
 
 // frame is a single program counter of a stack frame.
 type frame uintptr
 
-func (f frame) pc() uintptr {
-	return uintptr(f) - 1
-}
-
-func (f frame) get() *StackFrame {
-	fn := runtime.FuncForPC(f.pc())
+// get returns a human readable stack frame.
+func (f frame) get() StackFrame {
+	pc := uintptr(f) - 1
+	fn := runtime.FuncForPC(pc)
 	if fn == nil {
-		return &StackFrame{
+		return StackFrame{
 			Name: "unknown",
 			File: "unknown",
 		}
@@ -55,9 +79,9 @@ func (f frame) get() *StackFrame {
 	name := fn.Name()
 	i := strings.LastIndex(name, "/")
 	name = name[i+1:]
-	file, line := fn.FileLine(f.pc())
+	file, line := fn.FileLine(pc)
 
-	return &StackFrame{
+	return StackFrame{
 		Name: name,
 		File: file,
 		Line: line,
@@ -67,12 +91,18 @@ func (f frame) get() *StackFrame {
 // stack is an array of program counters.
 type stack []uintptr
 
+// get returns a human readable stack trace.
 func (s *stack) get() []StackFrame {
 	var sFrames []StackFrame
 	for _, f := range *s {
 		frame := frame(f)
 		sFrame := frame.get()
-		sFrames = append(sFrames, *sFrame)
+		sFrames = append(sFrames, sFrame)
 	}
 	return sFrames
+}
+
+func insert(s Stack, f StackFrame, at int) Stack {
+	// this inserts the frame by breaking the stack into two slices (s[:at] and s[at:])
+	return append(s[:at], append([]StackFrame{f}, s[at:]...)...)
 }


### PR DESCRIPTION
This commit includes a change to error wrapping that enables wrap error stack frames to be inserted into the root error stack trace. It also changes error formatting to display root errors first followed by wrapped errors in the same order as the stack trace (same order as runtime.Callers).