### PR TITLE
feat: wrap external errors instead of changing them to root errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ fmt.Println(formattedStr)
 
 ### Writing a custom output format
 
-`eris` also allows advanced users to construct custom error strings or objects in case the default error doesn't fit their requirements. The [`UnpackedError`](https://pkg.go.dev/github.com/rotisserie/eris#UnpackedError) object provides a convenient and developer friendly way to store and access existing error traces. The `ErrRoot` and `ErrChain` fields correspond to the root error and wrap error chain, respectively. If any other error type is unpacked, it will appear in the `ExternalErr` field. You can access all of the information contained in an error via [`eris.Unpack`](https://pkg.go.dev/github.com/rotisserie/eris#Unpack).
+`eris` also allows advanced users to construct custom error strings or objects in case the default error doesn't fit their requirements. The [`UnpackedError`](https://pkg.go.dev/github.com/rotisserie/eris#UnpackedError) object provides a convenient and developer friendly way to store and access existing error traces. The `ErrRoot` and `ErrChain` fields correspond to the root error and wrap error chain, respectively. If a root error wraps an external error, that error will be default formatted and assigned to the `ErrExternal` field. If any other error type is unpacked, it will appear in the `ErrExternal` field. You can access all of the information contained in an error via [`eris.Unpack`](https://pkg.go.dev/github.com/rotisserie/eris#Unpack).
 
 ```golang
 // get the unpacked error object
@@ -294,7 +294,7 @@ runtime.goexit
 
 Migrating to `eris` should be a very simple process. If it doesn't offer something that you currently use from existing error packages, feel free to submit an issue to us. If you don't want to refactor all of your error handling yet, `eris` should work relatively seamlessly with your existing error types. Please submit an issue if this isn't the case for some reason.
 
-Many of your dependencies will likely still use [pkg/errors](https://github.com/pkg/errors) for error handling. When external types are wrapped with additional context, `eris` attempts to unwrap them to build a new error chain. If an error type doesn't implement the unwrapping interface, the original error is flattened (via `err.Error()`) and used to create a new root error instead.
+Many of your dependencies will likely still use [pkg/errors](https://github.com/pkg/errors) for error handling. When external error types are wrapped with additional context, `eris` creates a new root error that wraps the original external error. Because of this, error inspection should work seamlessly with other error libraries.
 
 ## Contributing
 

--- a/examples/external/example.go
+++ b/examples/external/example.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 
 	pkgerrors "github.com/pkg/errors"
@@ -39,4 +40,7 @@ func processResource(id string) error {
 func main() {
 	err := processResource("res1")
 	fmt.Printf("%+v\n", err)
+	jsonErr := eris.ToJSON(err, true)
+	jsonStr, _ := json.Marshal(jsonErr)
+	fmt.Printf("%v\n", string(jsonStr))
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -103,8 +103,6 @@ func TestLocalStack(t *testing.T) {
 func TestExtGlobalStack(t *testing.T) {
 	// expected results
 	expectedChain := []eris.StackFrame{
-		{Name: readFunc, File: file, Line: 40},
-		{Name: readFunc, File: file, Line: 40},
 		{Name: processFunc, File: file, Line: 57},
 	}
 	expectedRoot := []eris.StackFrame{
@@ -112,7 +110,7 @@ func TestExtGlobalStack(t *testing.T) {
 		{Name: parseFunc, File: file, Line: 45},
 		{Name: processFunc, File: file, Line: 55},
 		{Name: processFunc, File: file, Line: 57},
-		{Name: extGlobalTestFunc, File: file, Line: 118},
+		{Name: extGlobalTestFunc, File: file, Line: 116},
 	}
 
 	err := ProcessFile("example.json", true, true)
@@ -124,8 +122,6 @@ func TestExtGlobalStack(t *testing.T) {
 func TestExtLocalStack(t *testing.T) {
 	// expected results
 	expectedChain := []eris.StackFrame{
-		{Name: readFunc, File: file, Line: 40},
-		{Name: readFunc, File: file, Line: 40},
 		{Name: processFunc, File: file, Line: 57},
 	}
 	expectedRoot := []eris.StackFrame{
@@ -133,7 +129,7 @@ func TestExtLocalStack(t *testing.T) {
 		{Name: parseFunc, File: file, Line: 45},
 		{Name: processFunc, File: file, Line: 55},
 		{Name: processFunc, File: file, Line: 57},
-		{Name: extLocalTestFunc, File: file, Line: 139},
+		{Name: extLocalTestFunc, File: file, Line: 135},
 	}
 
 	err := ProcessFile("example.json", false, true)


### PR DESCRIPTION
this PR is a redesign of the way eris wraps external errors. instead of unwrapping them and disguising them as root errors, it simply wraps them to maintain all error context. closes #82 and closes #81.